### PR TITLE
fix: max_layer upperbound

### DIFF
--- a/vat_pytorch/alicepp.py
+++ b/vat_pytorch/alicepp.py
@@ -42,7 +42,7 @@ class ALICEPPLoss(nn.Module):
         self.num_classes = num_classes
         self.loss_fn = loss_fn
         self.num_layers = num_layers
-        self.max_layer = default(max_layer, num_layers)
+        self.max_layer = min(default(max_layer, num_layers), num_layers) 
         self.loss_last_fn = default(loss_last_fn, loss_fn) 
         self.gold_loss_fn = default(gold_loss_fn, loss_fn)
         self.gold_loss_last_fn = default(default(gold_loss_last_fn, self.gold_loss_fn), self.loss_last_fn)


### PR DESCRIPTION
Prevent the user to set a max_layer larger than the total number of layers in the model. 